### PR TITLE
Configurable bind host

### DIFF
--- a/examples/DiscoveryTest.hs
+++ b/examples/DiscoveryTest.hs
@@ -154,7 +154,7 @@ main = do
 
     putStrLn $ "peerIndex " ++ show peerIndex
     putStrLn $ "peerPort " ++ show peerPort
-    kInstance <- K.createL port (KademliaID key) config logInfo logError
+    kInstance <- K.createL "127.0.0.1" port (KademliaID key) config logInfo logError
     when (peerPort /= 0) $ do
         putStrLn "Connecting to peer"
         r <- connectToPeer kInstance peerPort peerKey

--- a/src/Network/Kademlia/HashNodeId.hs
+++ b/src/Network/Kademlia/HashNodeId.hs
@@ -6,6 +6,8 @@ module Network.Kademlia.HashNodeId
        , hashAddress
        , nonceLen
        , verifyAddress
+       , meaningPartLength
+       , hashPartLength
        ) where
 
 import           Crypto.Hash            (Digest, SHA256 (..), SHA512, hash)
@@ -16,6 +18,14 @@ import           Data.ByteArray         (ByteArray, ByteArrayAccess)
 import qualified Data.ByteString        as B
 
 import           Network.Kademlia.Types (Serialize (..))
+
+-- TODO document. What is this?
+meaningPartLength :: Int
+meaningPartLength = 14
+
+-- TODO document. What is this?
+hashPartLength :: Int
+hashPartLength = 18
 
 newtype Nonce = Nonce B.ByteString
 

--- a/src/Network/Kademlia/Implementation.hs
+++ b/src/Network/Kademlia/Implementation.hs
@@ -151,6 +151,7 @@ joinNetwork inst node = ownId >>= runLookup go inst
                 then return NodeBanned
                 else do
                     -- Poll the supplied node
+                    --liftIO $ putStrLn $ "join: sending to " ++ show (peer node)
                     sendS node
                     -- Run a normal lookup from thereon out
                     waitForReply nodeDown checkSignal

--- a/src/Network/Kademlia/Networking.hs
+++ b/src/Network/Kademlia/Networking.hs
@@ -9,6 +9,7 @@ Network.Kademlia.Networking implements all the UDP network functionality.
 
 module Network.Kademlia.Networking
        ( KademliaHandle
+       , kSock
        , openOn
        , openOnL
        , startRecvProcess

--- a/src/Network/Kademlia/Networking.hs
+++ b/src/Network/Kademlia/Networking.hs
@@ -58,21 +58,22 @@ logError' h = logError h . show
 
 openOn
     :: (Show i, Serialize i, Serialize a)
-    => String -> i -> ReplyQueue i a -> IO (KademliaHandle i a)
-openOn port id' rq = openOnL port id' lim rq (const $ pure ()) (const $ pure ())
+    => String -> String -> i -> ReplyQueue i a -> IO (KademliaHandle i a)
+openOn host port id' rq = openOnL host port id' lim rq (const $ pure ()) (const $ pure ())
   where
     lim = msgSizeLimit defaultConfig
 
 -- | Open a Kademlia connection on specified port and return a corresponding
 --   KademliaHandle
-openOnL :: (Show i, Serialize i, Serialize a) => String -> i -> Int
-       -> ReplyQueue i a -> (String -> IO ()) -> (String -> IO ())
+openOnL :: (Show i, Serialize i, Serialize a) => String -> String
+       -> i -> Int -> ReplyQueue i a -> (String -> IO ()) -> (String -> IO ())
        -> IO (KademliaHandle i a)
-openOnL port id' lim rq logInfo logError = withSocketsDo $ do
+openOnL host port id' lim rq logInfo logError = withSocketsDo $ do
     -- Get addr to bind to
     serveraddrs <- getAddrInfo
                  (Just (defaultHints {addrFlags = [AI_PASSIVE]}))
-                 Nothing (Just port)
+                 (Just host)
+                 (Just port)
 
     -- TODO: support IPV6 by binding to two sockets
     let serveraddr = head $ filter (\a -> addrFamily a == AF_INET) serveraddrs

--- a/test/Implementation.hs
+++ b/test/Implementation.hs
@@ -36,7 +36,7 @@ import           TestTypes                 (IdBunch (..), IdType (..))
 constructNetwork :: IdBunch IdType -> PropertyM IO [KademliaInstance IdType String]
 constructNetwork idBunch = run $ do
     let entryNode = Node (Peer "127.0.0.1" 3123) (head . getIds $ idBunch)
-    instances <- zipWithM K.create [3123..] (getIds idBunch)
+    instances <- zipWithM (K.create "127.0.0.1") [3123..] (getIds idBunch)
                         :: IO [KademliaInstance IdType String]
 
     forM_ (tail instances) (`K.joinNetwork` entryNode)
@@ -72,7 +72,7 @@ idClashCheck idA idB = monadicIO $ do
         entryNode = Node (Peer "127.0.0.1" 1124) idB
 
     joinResult <- run $ do
-        insts@[kiA, _, kiB] <- zipWithM K.create [1123..] ids
+        insts@[kiA, _, kiB] <- zipWithM (K.create "127.0.0.1") [1123..] ids
                             :: IO [KademliaInstance IdType String]
 
         () <$ K.joinNetwork kiA entryNode
@@ -89,7 +89,7 @@ idClashCheck idA idB = monadicIO $ do
 nodeDownCheck :: Assertion
 nodeDownCheck = do
     let entryNode = Node (Peer "127.0.0.1" 1124) idB
-    inst <- K.create 1123 idA :: IO (KademliaInstance IdType String)
+    inst <- K.create "127.0.0.1" 1123 idA :: IO (KademliaInstance IdType String)
     joinResult <- K.joinNetwork inst entryNode
     K.close inst
 
@@ -105,7 +105,7 @@ joinBannedCheck idA idB = monadicIO $ do
     let entryNode = Node (Peer "127.0.0.1" 1124) idB
 
     joinResult <- run $ do
-        inst <- K.create 1123 idA :: IO (KademliaInstance IdType String)
+        inst <- K.create "127.0.0.1" 1123 idA :: IO (KademliaInstance IdType String)
 
         K.banNode inst idB $ BanForever
         joinResult <- K.joinNetwork inst entryNode

--- a/test/Instance.hs
+++ b/test/Instance.hs
@@ -69,8 +69,8 @@ handlesPingCheck = do
 
     rq <- emptyReplyQueue
 
-    khA <- openOn "1122" idA rq :: IO (KademliaHandle IdType String)
-    kiB <- create 1123 idB   :: IO (KademliaInstance IdType String)
+    khA <- openOn "127.0.0.1" "1122" idA rq :: IO (KademliaHandle IdType String)
+    kiB <- create "127.0.0.1" 1123 idB   :: IO (KademliaInstance IdType String)
 
     startRecvProcess khA
 
@@ -95,8 +95,8 @@ storeAndFindValueCheck key value = monadicIO $ do
     receivedCmd <- run $ do
         rq <- emptyReplyQueue
 
-        khA <- openOn "1122" idA rq
-        kiB <- create 1123 idB :: IO (KademliaInstance IdType String)
+        khA <- openOn "127.0.0.1" "1122" idA rq
+        kiB <- create "127.0.0.1" 1123 idB :: IO (KademliaInstance IdType String)
 
         startRecvProcess khA
 
@@ -133,8 +133,8 @@ trackingKnownPeersCheck = monadicIO $ do
     (node, kiB) <- run $ do
         rq <- emptyReplyQueue :: IO (ReplyQueue IdType String)
 
-        khA <- openOn "1122" idA rq
-        kiB <- create 1123 idB :: IO (KademliaInstance IdType String)
+        khA <- openOn "127.0.0.1" "1122" idA rq
+        kiB <- create "127.0.0.1" 1123 idB :: IO (KademliaInstance IdType String)
 
         startRecvProcess khA
 
@@ -158,7 +158,7 @@ trackingKnownPeersCheck = monadicIO $ do
 -- | Make sure `isNodeBanned` works correctly
 isNodeBannedCheck :: Assertion
 isNodeBannedCheck = do
-    inst <- create 1123 idA :: IO (KademliaInstance IdType String)
+    inst <- create "127.0.0.1" 1123 idA :: IO (KademliaInstance IdType String)
     let check msg ans = do
             ban <- isNodeBanned inst idB
             assertEqual msg ban ans
@@ -188,8 +188,8 @@ banNodeCheck = do
 
     rq <- emptyReplyQueue
 
-    khA <- openOn "1122" idA rq :: IO (KademliaHandle IdType String)
-    kiB <- create 1123 idB   :: IO (KademliaInstance IdType String)
+    khA <- openOn "127.0.0.1" "1122" idA rq :: IO (KademliaHandle IdType String)
+    kiB <- create "127.0.0.1" 1123 idB   :: IO (KademliaInstance IdType String)
 
     banNode kiB idA $ BanForever
     startRecvProcess khA

--- a/test/Networking.hs
+++ b/test/Networking.hs
@@ -46,8 +46,8 @@ sendCheck cmd = monadicIO $ do
         rqA <- emptyReplyQueue
         rqB <- emptyReplyQueue
 
-        khA <- openOn "1122" idA rqA
-        khB <- (openOn "1123" idB rqB
+        khA <- openOn "127.0.0.1" "1122" idA rqA
+        khB <- (openOn "127.0.0.1" "1123" idB rqB
                     :: IO (KademliaHandle IdType String))
 
         startRecvProcess khB
@@ -77,7 +77,7 @@ expectCheck sig idA = monadicIO $ do
     replySig <- run $ do
         rqA <- emptyReplyQueue
 
-        khA <- openOn "1122" idA rqA
+        khA <- openOn "127.0.0.1" "1122" idA rqA
 
         startRecvProcess khA
 


### PR DESCRIPTION
A host parameter can be given, so that your Kademlia won't always bind to the first address that `getAddrInfo` gives with no host hints (probably `0.0.0.0`).

Also included 2 unrelated but small commits. Check their messages for details.