### PR TITLE
Various corrections

### DIFF
--- a/src/Network/Kademlia.hs
+++ b/src/Network/Kademlia.hs
@@ -190,7 +190,7 @@ createLFromSnapshot
 createLFromSnapshot host port cfg snapshot logInfo logError = do
     rq <- emptyReplyQueueL logInfo logError
     let lim = msgSizeLimit cfg
-    let id' = T.extractId (spTree snapshot) `usingConfig` cfg
+    let id' = T.extractId (spTree snapshot)
     h <- openOnL host (show port) id' lim rq logInfo logError
     inst <- restoreInstance cfg h snapshot
     start inst rq

--- a/src/Network/Kademlia/Implementation.hs
+++ b/src/Network/Kademlia/Implementation.hs
@@ -66,7 +66,7 @@ lookup inst nid = runLookup go inst nid
                 polled <- gets polled
                 let rest = polled \\ known
                 unless (null rest) $ do
-                    let cachePeer = peer . head $ sortByDistanceTo rest nid `usingConfig` config inst
+                    let cachePeer = peer . head $ sortByDistanceTo rest nid
                     liftIO . send (handle inst) cachePeer . STORE nid $ value
 
                 -- Return the value
@@ -126,7 +126,7 @@ store inst key val = runLookup go inst key
                     peerNum = if length polled > k' then k' else length polled
                     -- Select the peers closest to the key
                     storePeers =
-                        map peer . take peerNum $ sortByDistanceTo polled key `usingConfig` config inst
+                        map peer . take peerNum $ sortByDistanceTo polled key
 
                 -- Send them a STORE command
                 forM_ storePeers $
@@ -347,7 +347,7 @@ continueLookup nodes signalAction continue end = do
     polled  <- gets polled
 
     -- Pick the k closest known nodes, that haven't been polled yet
-    let newKnown = take (k $ config inst) . (`usingConfig` config inst) . flip sortByDistanceTo nid . filter (`notElem` polled)
+    let newKnown = take (k $ config inst) . flip sortByDistanceTo nid . filter (`notElem` polled)
                       $ nodes ++ known
 
     -- Check if k closest nodes have been polled already
@@ -356,7 +356,7 @@ continueLookup nodes signalAction continue end = do
         then do
             -- Send signal to the closest node, that hasn't
             -- been polled yet
-            let next = head $ sortByDistanceTo newKnown nid `usingConfig` config inst
+            let next = head $ sortByDistanceTo newKnown nid
             signalAction next
 
             -- Update known
@@ -383,7 +383,7 @@ continueLookup nodes signalAction continue end = do
             polled <- gets polled
 
             -- Return the k closest nodes, the lookup had contact with
-            return . take (k $ config inst) $ sortByDistanceTo (known ++ polled) cid `usingConfig` config inst
+            return . take (k $ config inst) $ sortByDistanceTo (known ++ polled) cid
 
 -- Send a signal to a node
 sendSignal :: Ord i

--- a/src/Network/Kademlia/Tree.hs
+++ b/src/Network/Kademlia/Tree.hs
@@ -9,7 +9,8 @@ This module is designed to be used as a qualified import.
 -}
 
 module Network.Kademlia.Tree
-       ( NodeTree
+       ( NodeTree (..)
+       , NodeTreeElem (..)
        , create
        , insert
        , lookup

--- a/src/Network/Kademlia/Types.hs
+++ b/src/Network/Kademlia/Types.hs
@@ -30,9 +30,6 @@ import           Data.Word               (Word8)
 import           GHC.Generics            (Generic)
 import           Network.Socket          (PortNumber, SockAddr (..), inet_ntoa)
 
-import           Network.Kademlia.Config (WithConfig, getConfig)
-import qualified Network.Kademlia.Config as C
-
 -- | Representation of an UDP peer
 data Peer = Peer {
       peerHost :: String
@@ -58,13 +55,12 @@ instance Show i => Show (Node i) where
 instance Binary i => Binary (Node i)
 
 -- | Sort a bucket by the closeness of its nodes to a give Id
-sortByDistanceTo :: (Serialize i) => [Node i] -> i -> WithConfig [Node i]
-sortByDistanceTo bucket nid = do
-    let pack bk = zip bk <$> sequence (map f bk)
+sortByDistanceTo :: (Serialize i) => [Node i] -> i -> [Node i]
+sortByDistanceTo bucket nid = unpack . sort . pack $ bucket
+  where pack bk = zip bk (map f bk)
         f = distance nid . nodeId
         sort = sortBy (compare `on` snd)
         unpack = map fst
-    unpack . sort <$> pack bucket
 
 -- | A structure serializable into and parsable from a ByteString
 class Serialize a where
@@ -75,33 +71,29 @@ class Serialize a where
 type ByteStruct = [Bool]
 
 -- | Converts a Serialize into a ByteStruct
-toByteStruct :: (Serialize a) => a -> WithConfig ByteStruct
-toByteStruct s = do
-    k <- C.k <$> getConfig
-    let convert w = foldr (\i bits -> testBit w i : bits) [] [0..k]
-    return $ B.foldr (\w bits -> convert w ++ bits) [] $ toBS s
+toByteStruct :: (Serialize a) => a -> ByteStruct
+toByteStruct s = B.foldr (\w bits -> convert w ++ bits) [] $ toBS s
+  where convert w = foldr (\i bits -> testBit w i : bits) [] [0..7]
 
 -- | Convert a ByteStruct back to its ByteString form
-fromByteStruct :: (Serialize a) => ByteStruct -> WithConfig a
-fromByteStruct bs = do
-    k <- C.k <$> getConfig
-    let s = B.pack . foldr (\i ws -> createWord i : ws) [] $ indexes
-        indexes = [0..(length bs `div` (k + 1)) - 1]
-        createWord i = let pos = i * (k + 1)
-                       in foldr changeBit zeroBits [pos..pos + k]
+fromByteStruct :: (Serialize a) => ByteStruct -> a
+fromByteStruct bs = case fromBS s of
+                    (Right (converted, _)) -> converted
+                    (Left err) -> error $ "Failed to convert from ByteStruct: " ++ err
+  where s = B.pack . foldr (\i ws -> createWord i : ws) [] $ indexes
+        indexes = [0..(length bs `div` 8) - 1]
+        createWord i = let pos = i * 8
+                       in foldr changeBit zeroBits [pos..pos + 7]
         changeBit i w = if bs !! i
-              then setBit w (i `mod` (k + 1))
+              then setBit w (i `mod` 8)
               else w
-    case fromBS s of
-        (Right (converted, _)) -> return converted
-        (Left err) -> error $ "Failed to convert from ByteStruct: " ++ err
 
 -- Calculate the distance between two Ids, as specified in the Kademlia paper
-distance :: (Serialize i) => i -> i -> WithConfig ByteStruct
-distance idA idB = do
-    bsA <- toByteStruct idA
-    bsB <- toByteStruct idB
-    return $ zipWith xor bsA bsB
+distance :: (Serialize i) => i -> i -> ByteStruct
+distance idA idB =
+    let bsA = toByteStruct idA
+        bsB = toByteStruct idB
+    in  zipWith xor bsA bsB
   where xor a b = not (a && b) && (a || b)
 
 -- | Try to convert a SockAddr to a Peer

--- a/test/Implementation.hs
+++ b/test/Implementation.hs
@@ -72,18 +72,18 @@ idClashCheck idA idB = monadicIO $ do
         entryNode = Node (Peer "127.0.0.1" 1124) idB
 
     joinResult <- run $ do
-        insts@[kiA, _, kiB] <- zipWithM (K.create "127.0.0.1") [1123..] ids
-                            :: IO [KademliaInstance IdType String]
+        insts@[kiA1, _, kiA2] <-
+            zipWithM (K.create "127.0.0.1") [1123..] ids
+            :: IO [KademliaInstance IdType String]
 
-        () <$ K.joinNetwork kiA entryNode
-        joinResult <- K.joinNetwork kiB $ entryNode
+        () <$ K.joinNetwork kiA1 entryNode
+        joinResult <- K.joinNetwork kiA2 $ entryNode
 
         mapM_ K.close insts
 
         return joinResult
 
     assert $ joinResult == K.IDClash
-
 
 -- | Make sure an offline peer is detected
 nodeDownCheck :: Assertion

--- a/test/Tree.hs
+++ b/test/Tree.hs
@@ -44,20 +44,21 @@ lookupCheck tree node = usingDefaultConfig (T.lookup tree (nodeId node)) == Just
 -- | Check wether an inserted Node is retrievable
 insertCheck :: IdType -> Node IdType -> Bool
 insertCheck nid node = usingDefaultConfig $ do
-    tree <- join $ T.insert <$> T.create nid <*> pure node
+    tree <- T.insert (T.create nid) node
     return $ lookupCheck tree node
 
 -- | Make sure a deleted Node can't be retrieved anymore
 deleteCheck :: IdType -> Node IdType -> Bool
 deleteCheck nid node = usingDefaultConfig $ do
-    origin <- join $ T.insert <$> T.create nid <*> pure node
+    origin <- T.insert (T.create nid) node
     tree <- T.delete origin . nodeId $ node
     return . not . lookupCheck tree $ node
 
 withTree :: (T.NodeTree IdType -> [Node IdType] -> WithConfig a) ->
             NodeBunch IdType -> IdType -> a
 withTree f bunch nid = usingDefaultConfig $ do
-    tree <- join $ foldrM (flip T.insert) <$> (T.create nid) <*> pure (nodes bunch)
+    -- tree <- join $ foldrM (flip T.insert) <$> (T.create nid) <*> pure (nodes bunch)
+    tree <- foldrM (flip T.insert) (T.create nid) (nodes bunch)
     f tree $ nodes bunch
 
 splitCheck :: NodeBunch IdType -> IdType -> Property
@@ -94,7 +95,7 @@ refreshCheck = withTree $ \tree nodes -> do
 findClosestCheck :: IdType -> NodeBunch IdType -> IdType -> Property
 findClosestCheck nid = withTree $ \tree nodes -> do
     let contains node = isJust <$> T.lookup tree (nodeId node)
-        distanceF = distance nid . nodeId
+        distanceF = pure . distance nid . nodeId
     contained <- filterM contains nodes
     treeClosest <- T.findClosest tree nid $ k defaultConfig
     packed <- zip contained <$> mapM distanceF contained
@@ -118,9 +119,9 @@ pickupNotClosestDifferentCheck nid = withTree $ \tree _ -> do
 -- | Make sure `toView` represents tree correctly
 viewCheck :: NodeBunch IdType -> IdType -> Bool
 viewCheck = withTree $ \tree nodes -> do
-    originId  <- T.extractId tree
+    let originId = T.extractId tree
     let view = T.toView tree
-    sorted <- mapM (\bucket -> sort <$> mapM (distance originId . nodeId) bucket) view
+    sorted <- mapM (\bucket -> sort <$> mapM (pure . distance originId . nodeId) bucket) view
               -- distance to this node increases from bucket to bucket
     return $  increases (concat sorted)
               -- and view contains all nodes from tree

--- a/test/Types.hs
+++ b/test/Types.hs
@@ -22,11 +22,11 @@ import           TestTypes               (IdType)
 -- | Checks wether toByteStruct converts corretctly
 toByteStructCheck :: IdType -> Bool
 toByteStructCheck nid = foldl foldingFunc True [0..length converted - 1]
-    where converted = toByteStruct nid `usingConfig` defaultConfig
+    where converted = toByteStruct nid
           byteWords = B.unpack . toBS $ nid
           foldingFunc b i = b && (converted !! i == access byteWords i)
           access ws i = testBit (ws !! (i `div` 8)) (i `mod` 8)
 
 -- | Checks wether fromByteStruct converts corretctly
 fromByteStructCheck :: IdType -> Bool
-fromByteStructCheck nid = nid == (fromByteStruct =<< toByteStruct nid) `usingConfig` defaultConfig
+fromByteStructCheck nid = nid == (fromByteStruct . toByteStruct $ nid)


### PR DESCRIPTION
- The `k` config parameter was misused in `toByteStruct` and derivatives. Restored the original behaviour.
- The `IDClash` join result was commented out. That was due to misuse of the library: don't rejoin the network if you're already in the network.
- Tree constructors are exported.