### PR TITLE
Expose internal types for orphan instances

### DIFF
--- a/src/Network/Kademlia/Tree.hs
+++ b/src/Network/Kademlia/Tree.hs
@@ -12,6 +12,8 @@ This module is designed to be used as a qualified import.
 
 module Network.Kademlia.Tree
        ( NodeTree (..)
+       , NodeTreeElem(..)
+       , PingInfo(..)
        , create
        , insert
        , lookup

--- a/src/Network/Kademlia/Types.hs
+++ b/src/Network/Kademlia/Types.hs
@@ -20,6 +20,8 @@ module Network.Kademlia.Types
        , sortByDistanceTo
        , toByteStruct
        , toPeer
+       , unwrapPort
+       , wrapPort
        ) where
 
 import           Data.Bits                  (setBit, testBit, zeroBits)


### PR DESCRIPTION
Hey guys,

this small PR expose a bunch of internal types/functions needed for orphan deriving.