### PR TITLE
Cleanup redundant dependencies according to weeder

### DIFF
--- a/kademlia.cabal
+++ b/kademlia.cabal
@@ -47,8 +47,6 @@ library
   build-depends:       base                >= 4.7 && < 5
                      , bytestring          >= 0.10.2 && < 0.11
                      , containers          >= 0.5.5.1
-                     , data-default        >= 0.7
-                     , errors
                      , extra               >= 1.4
                      , memory
                      , MonadRandom
@@ -60,7 +58,6 @@ library
                      , store
                      , time                >= 1.6
                      , transformers        >= 0.3
-                     , transformers-compat >= 0.3.3
                      , cryptonite
                      , contravariant
 


### PR DESCRIPTION
For reference full report:

= Package kademlia =

== Section exe:discovery-test ==
Redundant build-depends entry
* data-default
* transformers-compat

== Section library ==
Redundant build-depends entry
* data-default
* errors
* transformers-compat

== Section test:library-test ==
Module not compiled
* Implementation
* Instance
* Networking
* Protocol
* ReplyQueue
* Test.hs
* TestTypes
* Tree
* Types
Redundant build-depends entry
* HUnit
* MonadRandom
* QuickCheck
* base
* binary
* bytestring
* containers
* data-default
* errors
* extra
* kademlia
* mtl
* network
* quickcheck-instances
* random
* random-shuffle
* stm
* tasty
* tasty-hunit
* tasty-quickcheck
* time
* transformers
* transformers-compat