### PR TITLE
[CSL - 1393] Remove store from Kademlia

### DIFF
--- a/kademlia.cabal
+++ b/kademlia.cabal
@@ -55,7 +55,6 @@ library
                      , random
                      , random-shuffle
                      , stm                 >= 2.4.3
-                     , store
                      , time                >= 1.6
                      , transformers        >= 0.3
                      , cryptonite

--- a/src/Network/Kademlia/Instance.hs
+++ b/src/Network/Kademlia/Instance.hs
@@ -41,7 +41,6 @@ import           Control.Monad.Trans.Reader  ()
 import           Control.Monad.Trans.State   ()
 import           Data.Map                    (Map)
 import qualified Data.Map                    as M hiding (Map)
-import           Data.Store                  (Store)
 import           Data.Time.Clock.POSIX       (getPOSIXTime)
 import           Data.Word                   (Word16)
 import           GHC.Generics                (Generic)
@@ -83,10 +82,6 @@ data KademliaSnapshot i
       spTree   :: T.NodeTree i
     , spBanned :: Map Peer BanState
     } deriving (Generic)
-
-instance Store BanState
-
-instance Store i => Store (KademliaSnapshot i)
 
 -- | Create a new KademliaInstance from an Id and a KademliaHandle
 newInstance

--- a/src/Network/Kademlia/Tree.hs
+++ b/src/Network/Kademlia/Tree.hs
@@ -33,7 +33,6 @@ import           Control.Arrow           (second)
 import           Control.Monad.Random    (evalRand)
 import qualified Data.List               as L (delete, find, genericTake)
 import qualified Data.Map                as M
-import           Data.Store              (Store)
 import           GHC.Generics            (Generic)
 import           System.Random           (StdGen)
 import           System.Random.Shuffle   (shuffleM)
@@ -66,12 +65,6 @@ type NodeTreeFunction i a
     -> M.Map Peer i
     -> ([(Node i, PingInfo)], [Node i])
     -> WithConfig a
-
-instance Store PingInfo
-
-instance Store i => Store (NodeTree i)
-
-instance Store i => Store (NodeTreeElem i)
 
 -- | Create a NodeTree corresponding to the id
 create :: (Serialize i) => i -> WithConfig (NodeTree i)

--- a/src/Network/Kademlia/Types.hs
+++ b/src/Network/Kademlia/Types.hs
@@ -30,8 +30,6 @@ import           Data.Function              (on)
 import           Data.Functor.Contravariant (contramap)
 import           Data.Int                   (Int64)
 import           Data.List                  (sortBy)
-import           Data.Store                 (Size (..), Store (..))
-import qualified Data.Store.Internal        as Store (getSize)
 import           Data.Word                  (Word16)
 import           Data.Word                  (Word8)
 import           GHC.Generics               (Generic)
@@ -52,19 +50,8 @@ unwrapPort = fromIntegral
 wrapPort :: Word16 -> PortNumber
 wrapPort = fromIntegral
 
-instance Store PortNumber where
-    size = contramap unwrapPort size
-    poke = poke . unwrapPort
-    peek = wrapPort <$> peek
-
 instance Show Peer where
     show (Peer h p) = h ++ ":" ++ show p
-
-instance Store Peer where
-    size = VarSize $ \Peer{..} ->
-        Store.getSize peerHost + Store.getSize (unwrapPort peerPort)
-    poke (Peer h p) = poke h >> poke (unwrapPort p)
-    peek = Peer <$> peek <*> (wrapPort <$> peek)
 
 -- | Representation of a Kademlia Node, containing a Peer and an Id
 data Node i = Node {
@@ -74,8 +61,6 @@ data Node i = Node {
 
 instance Show i => Show (Node i) where
   show (Node peer nodeId) = show peer ++ " (" ++ show nodeId ++ ")"
-
-instance Store i => Store (Node i)
 
 -- | Sort a bucket by the closeness of its nodes to a give Id
 sortByDistanceTo :: (Serialize i) => [Node i] -> i -> WithConfig [Node i]


### PR DESCRIPTION
This PR effectively removes `store` from `kademlia` and is suitable to be incorporated into `cardano` after [this PR](https://github.com/input-output-hk/cardano-sl/pull/1203) will be merged.

